### PR TITLE
feat: add `preserve_order` feature to value object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +61,23 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "indexmap"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -131,8 +154,10 @@ dependencies = [
 name = "serde-envfile"
 version = "0.2.0"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "envy",
+ "indexmap",
  "log",
  "serde",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,20 @@ description = """
 keywords = ["serde", "env", "serialization", "deserialization"]
 
 [dependencies]
+cfg-if = "1.0"
+dotenvy = "0.15"
+envy = "0.4"
+indexmap = { version = "2.8.0", optional = true, features = ["serde"] }
 log = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
-envy = "0.4"
-dotenvy = "0.15"
 
 [dev-dependencies]
 tempfile = "3.19"
 
 [features]
 debug = ["dep:log"]
+
+# Make serde_envfile::Value use a representation which maintains insertion order.
+# This allows data to be read into a Value and written back to a envfile string
+# while preserving the order of map keys in the input.
+preserve_order = ["dep:indexmap"]

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,7 +1,14 @@
-use std::ops::{Deref, DerefMut};
-use std::collections::HashMap;
+//! The Value object, a loosely typed way of representing any valid envfile content.
 
-use serde::{Deserialize, Serialize};
+cfg_if::cfg_if! {
+    if #[cfg(feature = "preserve_order")] {
+        use indexmap::IndexMap as Map;
+    } else {
+        // std::collections::HashMap vs hashbrown::HashMap
+        // https://users.rust-lang.org/t/hashmap-and-hashbrown/114535/2
+        use std::collections::HashMap as Map;
+    }
+}
 
 /// Flexible representation of environment variables.
 ///
@@ -19,49 +26,92 @@ use serde::{Deserialize, Serialize};
 ///     Ok(())
 /// }
 /// ```
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
-pub struct Value {
-    #[serde(flatten)]
-    inner: HashMap<String, String>,
-}
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct Value(Map<String, String>);
 
 impl Value {
+    /// Create an empty [`Value`].
+    ///
+    /// Internally, the [`Value`] object uses a map to store the key-value pairs.
     pub fn new() -> Self {
-        Self {
-            inner: HashMap::new(),
-        }
+        Self(Default::default())
     }
 }
 
-impl Deref for Value {
-    type Target = HashMap<String, String>;
+impl Default for Value {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::ops::Deref for Value {
+    type Target = Map<String, String>;
+
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        &self.0
     }
 }
 
-impl DerefMut for Value {
+impl std::ops::DerefMut for Value {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
+        &mut self.0
+    }
+}
+
+impl<K,V> FromIterator<(K,V)> for Value
+where
+    K: Into<String>,
+    V: Into<String>,
+{
+    /// Create a new [`Value`] from an iterator of key-value pairs.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use serde_envfile::Value;
+    /// 
+    /// let env = Value::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
+    /// # assert_eq!(env.get("KEY1").unwrap(), "VALUE1");
+    /// # assert_eq!(env.get("KEY2").unwrap(), "VALUE2");
+    /// ```
+    ///
+    fn from_iter<T: IntoIterator<Item = (K,V)>>(iter: T) -> Self {
+        let iter = iter.into_iter().map(|(k,v)| (k.into(), v.into()));
+        Self(FromIterator::from_iter(iter))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{from_str, to_string};
+    use super::Value;
+    use crate::{de::from_str, ser::to_string};
 
     #[test]
-    fn to_env_test() {
-        let mut env = Value::new();
-        env.insert("serde_envfile".into(), "HELLO WORLD".into());
+    fn value_to_string() {
+        //* Given
+        let env = Value::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
 
-        let s = to_string(&env).unwrap();
-        let expected = "SERDE_ENVFILE=\"HELLO WORLD\"";
-        assert_eq!(expected, s);
+        //* When
+        let value_serialized = to_string(&env).expect("Failed to convert Value to String");
+        let value_deserialized = from_str::<Value>(&value_serialized).expect("Failed to deserialize Value");
 
-        let d: Value = from_str(&s).unwrap();
+        //* Then
+        // Assert that both expected lines are present
+        // The order of keys in the serialized output is not guaranteed without the `preserve_order` feature
+        assert!(value_serialized.contains(r#"KEY1="VALUE1""#));
+        assert!(value_serialized.contains(r#"KEY2="VALUE2""#));
 
-        assert_eq!(env, d);
+        // Assert the deserialize output follows the order of the original input
+        // when the `preserve_order` feature is enabled
+        #[cfg(feature = "preserve_order")] 
+        {
+            let expected_serialized = "KEY1=\"VALUE1\"\nKEY2=\"VALUE2\"";
+            assert_eq!(value_serialized, expected_serialized);
+        }
+
+        // Create a new Value with lowercase keys to match the deserialization behavior
+        let expected_deserialized = Value::from_iter([("key1", "VALUE1"), ("key2", "VALUE2")]);
+        assert_eq!(value_deserialized, expected_deserialized);
     }
 }


### PR DESCRIPTION
This pull request includes several changes to the `serde_envfile` crate to improve its functionality and maintainability. The most significant changes include adding new dependencies, modifying the `Value` struct to use a map that can preserve insertion order, and updating the test cases to reflect these changes.

- Add `preserve_order` crate feature to value object.
- Add `Value::from_iter` method to create a `Value` object from an iterator of key-value pairs.
- Enhance value module documentation and unit tests.