### PR TITLE
refactor: move public API tests to integration tests directory

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,34 +65,3 @@ pub use value::Value;
 
 pub use prefixed::Prefixed;
 pub use prefixed::prefixed;
-
-#[cfg(test)]
-mod tests {
-    use crate::{Value, from_str, to_string};
-    use serde::{Deserialize, Serialize};
-
-    #[test]
-    fn basic_main() {
-        #[derive(Debug, Deserialize, Serialize)]
-        struct Test {
-            hello: String,
-        }
-
-        let de = "HELLO=\"WORLD\"";
-        let test: Test = from_str(de).unwrap();
-        let ser = to_string(&test).unwrap();
-
-        assert_eq!(de, ser)
-    }
-
-    #[test]
-    fn value_main() {
-        let mut env = Value::new();
-        env.insert("hello".into(), "world".into());
-        let ser = to_string(&env).unwrap();
-
-        let de: Value = from_str(&ser).unwrap();
-
-        assert_eq!(env, de);
-    }
-}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,0 +1,36 @@
+use serde_envfile::{from_str, to_string, Value};
+
+#[test]
+fn derive_serde() {
+    //* Given
+    // Test struct with serde derive
+    #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    struct TestEnvFile {
+        hello: String,
+    }
+
+    let input = "HELLO=\"WORLD\"";
+
+    //* When
+    // Serialize and deserialize
+    let de_output = from_str::<TestEnvFile>(input).expect("Failed to deserialize");
+    let ser_output = to_string(&de_output).expect("Failed to serialize");
+
+    //* Then
+    assert_eq!(input, ser_output);
+}
+
+#[test]
+fn value_serde() {
+    //* Given
+    let mut env = Value::new();
+    env.insert("hello".into(), "world".into());
+
+    //* When
+    // Serialize and deserialize
+    let ser_output = to_string(&env).expect("Failed to serialize");
+    let de_output = from_str::<Value>(&ser_output).expect("Failed to deserialize");
+
+    //* Then
+    assert_eq!(env, de_output);
+}


### PR DESCRIPTION
- Removed inline tests from `lib.rs` and created a new `basic.rs` file for testing.
- Updated test cases to use the new structure while ensuring they validate serialization and deserialization of environment variables correctly.