### PR TITLE
feat: add `from_reader` and `to_writer` functions

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1,12 +1,10 @@
 use std::path::Path;
 
-use serde::de;
-
-use crate::{Error, error::Result};
+use super::error::{Error, Result};
 
 pub fn from_iter<T, Iter>(iter: Iter) -> Result<T>
 where
-    T: de::DeserializeOwned,
+    T: serde::de::DeserializeOwned,
     Iter: IntoIterator<Item = (String, String)>,
 {
     from_iter_inner::<T, Iter>(None, iter)
@@ -14,18 +12,17 @@ where
 
 pub fn from_iter_inner<T, Iter>(prefix: Option<&str>, iter: Iter) -> Result<T>
 where
-    T: de::DeserializeOwned,
+    T: serde::de::DeserializeOwned,
     Iter: IntoIterator<Item = (String, String)>,
 {
     match prefix {
-        Some(pref) => {
-            envy::prefixed(pref.to_uppercase()).from_iter::<_, T>(iter)
-        }
+        Some(pref) => envy::prefixed(pref.to_uppercase()).from_iter::<_, T>(iter),
         None => {
             // No prefix provided, use default behavior
             envy::from_iter::<_, T>(iter)
         }
-    }.map_err(Error::new)
+    }
+    .map_err(Error::new)
 }
 
 /// Deserialize program-available environment variables into an instance of type `T`.
@@ -45,32 +42,26 @@ where
 ///     user: String,
 /// }
 ///
-/// fn from_env_example() -> Result<(), Error> {
-///     let t: Test = from_env()?;
-///     println!("{:?}", t);
-///
-///     Ok(())
-/// }
+/// let value = from_env::<Test>().expect("Failed to deserialize from environment");
+/// 
+/// println!("{:?}", value);
 /// ```
 pub fn from_env<T>() -> Result<T>
 where
-    T: de::DeserializeOwned,
+    T: serde::de::DeserializeOwned,
 {
     from_env_inner(None)
 }
 
 pub fn from_env_inner<T>(prefix: Option<&str>) -> Result<T>
 where
-    T: de::DeserializeOwned,
+    T: serde::de::DeserializeOwned,
 {
     match prefix {
-        Some(pref) => {
-            envy::prefixed(pref.to_uppercase()).from_env::<T>()
-        }
-        None => {
-            envy::from_env::<T>()
-        }
-    }.map_err(Error::new)
+        Some(pref) => envy::prefixed(pref.to_uppercase()).from_env::<T>(),
+        None => envy::from_env::<T>(),
+    }
+    .map_err(Error::new)
 }
 
 /// Deserialize environment variables from a string into an instance of type `T`.
@@ -80,24 +71,21 @@ where
 /// ```
 /// use serde_envfile::{from_str, Value, Error};
 ///
-/// fn from_str_example() -> Result<(), Error> {
-///     let e = "HELLO=world";
-///     let v: Value = from_str(e)?;
-///     println!("{:?}", v);
-///
-///     Ok(())
-/// }
+/// let env = "HELLO=world";
+/// let value = from_str::<Value>(env).expect("Failed to deserialize from string");
+/// 
+/// println!("{:?}", value);
 /// ```
 pub fn from_str<T>(input: &str) -> Result<T>
 where
-    T: de::DeserializeOwned,
+    T: serde::de::DeserializeOwned,
 {
     from_str_inner::<T>(None, input)
 }
 
 pub fn from_str_inner<'a, T>(prefix: Option<&'a str>, input: &'a str) -> Result<T>
 where
-    T: de::DeserializeOwned,
+    T: serde::de::DeserializeOwned,
 {
     let mut env = Vec::new();
 
@@ -109,37 +97,69 @@ where
     from_iter_inner::<T, _>(prefix, env)
 }
 
-/// Deserialize an environment variable file into an instance of type `T`.
+/// Deserialize environment variables from a reader into an instance of type `T`.
 ///
 /// # Example
 ///
 /// ```
+/// use std::io::Cursor;
+/// use serde_envfile::{from_reader, Value, Error};
+///
+/// let input = Cursor::new("HELLO=world");
+/// let value = from_reader::<_, Value>(input).expect("Envfile deserialization failed");
+///
+/// println!("{:?}", value);
+/// ```
+pub fn from_reader<R, T>(reader: R) -> Result<T>
+where
+    R: std::io::Read,
+    T: serde::de::DeserializeOwned,
+{
+    from_reader_inner(None, reader)
+}
+
+pub(crate) fn from_reader_inner<R, T>(prefix: Option<&str>, reader: R) -> Result<T>
+where
+    R: std::io::Read,
+    T: serde::de::DeserializeOwned,
+{
+    let mut env = Vec::new();
+
+    for pair in dotenvy::from_read_iter(reader) {
+        let (key, value) = pair.map_err(Error::new)?;
+        env.push((key, value));
+    }
+
+    from_iter_inner::<T, _>(prefix, env)
+}
+
+/// Deserialize an environment variable file into an instance of type `T`.
+///
+/// # Example
+///
+/// ```no_run
 /// use std::path::PathBuf;
-/// use serde_envfile::{from_file, Value, Error};
+/// use serde_envfile::{Value, from_file};
 ///
-/// fn from_file_example() -> Result<(), Error> {
-///     let v: Value = from_file(&PathBuf::from(".env"))?;
-///     println!("{:?}", v);
-///
-///     Ok(())
-/// }
+/// let path = PathBuf::from(".env");
+/// let value = from_file::<Value>(&path).expect("Failed to deserialize from file");
+/// 
+/// println!("{:?}", value);
 /// ```
 pub fn from_file<T>(path: &Path) -> Result<T>
 where
-    T: de::DeserializeOwned,
+    T: serde::de::DeserializeOwned,
 {
     from_file_inner(None, path)
 }
 
 pub fn from_file_inner<T>(prefix: Option<&str>, path: &Path) -> Result<T>
 where
-    T: de::DeserializeOwned,
+    T: serde::de::DeserializeOwned,
 {
     let mut env = Vec::new();
 
-    for pair in dotenvy::from_filename_iter(path)
-        .map_err(Error::new)?
-    {
+    for pair in dotenvy::from_filename_iter(path).map_err(Error::new)? {
         let (key, value) = pair.map_err(Error::new)?;
         env.push((key, value));
     }
@@ -152,12 +172,12 @@ mod tests {
     use std::{
         env::{set_var, vars},
         fs::write,
-        io::{SeekFrom, prelude::*},
+        io::{Cursor, Seek, SeekFrom},
     };
 
     use tempfile::NamedTempFile;
 
-    use super::*;
+    use super::{from_env, from_file, from_reader, from_str};
     use crate::Value;
 
     #[test]
@@ -185,13 +205,28 @@ mod tests {
     }
 
     #[test]
+    fn deserialize_from_reader() {
+        //* Given
+        let input = "HELLO=world";
+
+        let reader = Cursor::new(input);
+
+        //* When
+        let env: Value = from_reader(reader).expect("Failed to deserialize from reader");
+
+        //* Then
+        assert_eq!(env.len(), 1);
+        assert_eq!("world", env.get("hello").unwrap());
+    }
+
+    #[test]
     fn from_file_test() {
         let input = "HELLO=world";
         let mut file = NamedTempFile::new().unwrap();
         write(file.path(), input).unwrap();
         file.seek(SeekFrom::Start(0)).unwrap();
 
-        let env: Value = from_file(file.path()).unwrap();
+        let env: Value = from_file(file.path()).expect("Failed to deserialize from file");
 
         assert_eq!(env.len(), 1);
         assert_eq!("world", env.get("hello").unwrap());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,20 +51,11 @@ pub(crate) mod prefixed;
 pub(crate) mod ser;
 pub(crate) mod value;
 
+pub use de::{from_env, from_file, from_reader, from_str};
 pub use error::Error;
-
-pub use de::from_env;
-pub use de::from_file;
-pub use de::from_str;
-
-pub use ser::Serializer;
-pub use ser::to_file;
-pub use ser::to_string;
-
+pub use prefixed::{Prefixed, prefixed};
+pub use ser::{Serializer, to_file, to_string, to_writer};
 pub use value::Value;
-
-pub use prefixed::Prefixed;
-pub use prefixed::prefixed;
 
 #[cfg(test)]
 mod tests {

--- a/src/prefixed.rs
+++ b/src/prefixed.rs
@@ -1,85 +1,216 @@
 use std::path::Path;
 
-use crate::de::{from_env_inner, from_file_inner, from_str_inner};
-use crate::error::Result;
-use crate::ser::{to_file_inner, to_string_inner};
-use serde::{de, ser};
+use super::{
+    de::{from_env_inner, from_file_inner, from_reader_inner, from_str_inner},
+    error::Result,
+    ser::{to_file_inner, to_string_inner, to_writer_inner},
+};
 
-/// Helper structure to work with prefixes more efficiently.
-/// Instantiable through [prefixed].
+/// Instantiates [`Prefixed`] from which values can be both serialized and deserialized with a prefix.
+///
+/// The prefix is added to all keys during serialization and is expected to be present during deserialization.
+/// This is useful for namespacing environment variables to avoid conflicts.
+///
+/// # Examples
+///
+/// ## Serializing with a prefix
+///
+/// ```
+/// use serde::{Serialize};
+/// use serde_envfile::{prefixed, Error};
+///
+/// #[derive(Serialize)]
+/// struct Config {
+///     database_url: String,
+///     port: u16,
+/// }
+///
+/// fn main() -> Result<(), Error> {
+///     let config = Config {
+///         database_url: "postgres://localhost/mydb".to_string(),
+///         port: 8080,
+///     };
+///
+///     // Serialize with "APP_" prefix
+///     let env_string = prefixed("APP_").to_string(&config)?;
+///     // Results in: APP_DATABASE_URL="postgres://localhost/mydb"\nAPP_PORT="8080"
+///
+///     println!("{}", env_string);
+///     Ok(())
+/// }
+/// ```
+///
+/// ## Deserializing with a prefix
+///
+/// ```
+/// use serde::{Deserialize};
+/// use serde_envfile::{prefixed, Error};
+///
+/// #[derive(Deserialize, Debug)]
+/// struct Config {
+///     database_url: String,
+///     port: u16,
+/// }
+///
+/// fn main() -> Result<(), Error> {
+///     let env_string = "APP_DATABASE_URL=\"postgres://localhost/mydb\"\nAPP_PORT=\"8080\"";
+///
+///     // Deserialize with "APP_" prefix
+///     let config: Config = prefixed("APP_").from_str(env_string)?;
+///
+///     assert_eq!(config.database_url, "postgres://localhost/mydb");
+///     assert_eq!(config.port, 8080);
+///     
+///     Ok(())
+/// }
+/// ```
+pub fn prefixed(prefix: &str) -> Prefixed {
+    Prefixed(prefix)
+}
+
+/// Helper structure to work with prefixed environment variables more efficiently.
+///
+/// This struct provides methods for serializing and deserializing data with a consistent prefix.
+/// Use the [`prefixed`] function to create an instance of this struct.
 pub struct Prefixed<'a>(&'a str);
 
 impl<'a> Prefixed<'a> {
     pub fn from_env<T>(&self) -> Result<T>
     where
-        T: de::DeserializeOwned,
+        T: serde::de::DeserializeOwned,
     {
         from_env_inner::<T>(Some(self.0))
     }
 
     pub fn from_str<T>(&self, input: &'a str) -> Result<T>
     where
-        T: de::DeserializeOwned,
+        T: serde::de::DeserializeOwned,
     {
         from_str_inner::<T>(Some(self.0), input)
     }
 
+    pub fn from_reader<R, T>(&self, reader: R) -> Result<T>
+    where
+        R: std::io::Read,
+        T: serde::de::DeserializeOwned,
+    {
+        from_reader_inner::<R, T>(Some(self.0), reader)
+    }
+
     pub fn from_file<T>(&self, path: &Path) -> Result<T>
     where
-        T: de::DeserializeOwned,
+        T: serde::de::DeserializeOwned,
     {
         from_file_inner::<T>(Some(self.0), path)
     }
 
     pub fn to_string<T>(&self, v: &T) -> Result<String>
     where
-        T: ser::Serialize,
+        T: serde::ser::Serialize,
     {
         to_string_inner(Some(self.0), v)
     }
 
-    pub fn to_file<T>(&self, path: &Path, v: &T) -> Result<()>
+    pub fn to_writer<W, T>(&self, writer: W, v: &T) -> Result<()>
     where
-        T: ser::Serialize,
+        W: std::io::Write,
+        T: serde::ser::Serialize,
+    {
+        to_writer_inner(Some(self.0), writer, v)
+    }
+
+    pub fn to_file<P, T>(&self, path: P, v: &T) -> Result<()>
+    where
+        P: AsRef<Path>,
+        T: serde::ser::Serialize,
     {
         to_file_inner(Some(self.0), path, v)
     }
 }
 
-/// Instantiates [Prefixed] from which values can be both serialized and deserialized.
-pub fn prefixed(prefix: &str) -> Prefixed {
-    Prefixed(prefix)
-}
-
 #[cfg(test)]
 mod tests {
-    use serde::Deserialize;
+    use std::io::Cursor;
 
-    use super::*;
-
+    use super::prefixed;
     use crate::Value;
 
     #[test]
-    fn ser_prefix_test() {
-        let mut v = Value::new();
-        v.insert("hello".into(), "world".into());
+    fn serialize_to_string_with_prefix() {
+        //* Given
+        let value = Value::from_iter([("hello", "world")]);
 
-        let s = prefixed("serde_envfile_").to_string(&v).unwrap();
-        let expected = "SERDE_ENVFILE_HELLO=\"world\"";
-        assert_eq!(expected, s);
-    }
+        //* When
+        let output = prefixed("serde_envfile_")
+            .to_string(&value)
+            .expect("Failed to serialize");
 
-    #[derive(Deserialize, Debug, PartialEq)]
-    struct Config {
-        hello: String,
+        //* Then
+        let expected_output = "SERDE_ENVFILE_HELLO=\"world\"";
+        assert_eq!(output, expected_output);
     }
 
     #[test]
-    fn de_prefix_test() {
+    fn deserilize_from_str_with_prefix() {
+        //* Given
+        #[derive(Debug, PartialEq, serde::Deserialize)]
+        struct Config {
+            hello: String,
+        }
+
         let env = "SERDE_ENVFILE_HELLO=\"world\"";
-        let v = prefixed("serde_envfile_").from_str::<Value>(env).unwrap();
-        let mut expected = Value::new();
-        expected.insert("hello".into(), "world".into());
-        assert_eq!(expected, v);
+
+        //* When
+        let output = prefixed("serde_envfile_")
+            .from_str::<Config>(env)
+            .expect("Failed to deserialize");
+
+        //* Then
+        let expected_output = Config {
+            hello: String::from("world"),
+        };
+        assert_eq!(output, expected_output);
+    }
+
+    #[test]
+    fn serialize_to_writer_with_prefix() {
+        //* Given
+        let value = Value::from_iter([("hello", "world")]);
+
+        let mut buffer = Vec::new();
+
+        //* When
+        prefixed("serde_envfile_")
+            .to_writer(&mut buffer, &value)
+            .expect("Failed to serialize to writer");
+
+        //* Then
+        let expected_output = "SERDE_ENVFILE_HELLO=\"world\"";
+        let output = String::from_utf8(buffer).expect("Invalid UTF-8 sequence");
+        assert_eq!(output, expected_output);
+    }
+
+    #[test]
+    fn deserialize_from_reader_with_prefix() {
+        //* Given
+        #[derive(Debug, PartialEq, serde::Deserialize)]
+        struct Config {
+            hello: String,
+        }
+
+        let env = "SERDE_ENVFILE_HELLO=\"world\"";
+
+        let reader = Cursor::new(env);
+
+        //* When
+        let output = prefixed("serde_envfile_")
+            .from_reader::<_, Config>(reader)
+            .expect("Failed to deserialize from reader");
+
+        //* Then
+        let expected_output = Config {
+            hello: String::from("world"),
+        };
+        assert_eq!(output, expected_output);
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -57,7 +57,7 @@ impl std::ops::DerefMut for Value {
     }
 }
 
-impl<K,V> FromIterator<(K,V)> for Value
+impl<K, V> FromIterator<(K, V)> for Value
 where
     K: Into<String>,
     V: Into<String>,
@@ -68,14 +68,14 @@ where
     ///
     /// ```rust
     /// use serde_envfile::Value;
-    /// 
+    ///
     /// let env = Value::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
     /// # assert_eq!(env.get("KEY1").unwrap(), "VALUE1");
     /// # assert_eq!(env.get("KEY2").unwrap(), "VALUE2");
     /// ```
     ///
-    fn from_iter<T: IntoIterator<Item = (K,V)>>(iter: T) -> Self {
-        let iter = iter.into_iter().map(|(k,v)| (k.into(), v.into()));
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        let iter = iter.into_iter().map(|(k, v)| (k.into(), v.into()));
         Self(FromIterator::from_iter(iter))
     }
 }
@@ -92,7 +92,8 @@ mod tests {
 
         //* When
         let value_serialized = to_string(&env).expect("Failed to convert Value to String");
-        let value_deserialized = from_str::<Value>(&value_serialized).expect("Failed to deserialize Value");
+        let value_deserialized =
+            from_str::<Value>(&value_serialized).expect("Failed to deserialize Value");
 
         //* Then
         // Assert that both expected lines are present
@@ -102,7 +103,7 @@ mod tests {
 
         // Assert the deserialize output follows the order of the original input
         // when the `preserve_order` feature is enabled
-        #[cfg(feature = "preserve_order")] 
+        #[cfg(feature = "preserve_order")]
         {
             let expected_serialized = "KEY1=\"VALUE1\"\nKEY2=\"VALUE2\"";
             assert_eq!(value_serialized, expected_serialized);


### PR DESCRIPTION
- Implemented `from_reader` to deserialize environment variables from a reader.
- Added `to_writer` to serialize data to a writer.
- Updated `Prefixed` struct to include methods for reading from a reader and writing to a writer.
- Enhanced documentation with examples for both new functions.