### PR TITLE
fix(ser): escape quotes, backslashes, dollars, newlines in string values

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -234,7 +234,15 @@ impl serde::ser::Serializer for &mut Serializer {
             self.output += &key;
         } else if !v.is_empty() {
             self.output += "\"";
-            self.output += v;
+            for c in v.chars() {
+                match c {
+                    '\\' => self.output += r"\\",
+                    '"' => self.output += r#"\""#,
+                    '$' => self.output += r"\$",
+                    '\n' => self.output += r"\n",
+                    _ => self.output.push(c),
+                }
+            }
             self.output += "\"";
         }
         Ok(())
@@ -851,5 +859,31 @@ mod tests {
         let expected_output = "HELLO=\"WORLD\"";
         let output = std::fs::read_to_string(file.path()).expect("Failed to read file");
         assert_eq!(expected_output, output);
+    }
+
+    #[test]
+    fn serialize_escapes_special_chars() {
+        // Values containing double quotes, backslashes, dollar signs, or newlines
+        // must be escaped so the serialized output parses back into the same value.
+        let cases = [
+            ("JSON", r#"{"bar":"baz"}"#, r#"JSON="{\"bar\":\"baz\"}""#),
+            ("BACKSLASH", r"a\b", r#"BACKSLASH="a\\b""#),
+            ("DOLLAR", "price $5", r#"DOLLAR="price \$5""#),
+            ("NEWLINE", "line1\nline2", r#"NEWLINE="line1\nline2""#),
+        ];
+
+        for (key, value, expected) in cases {
+            let env = Value::from_iter([(key, value)]);
+            let output = to_string(&env).expect("Failed to serialize to string");
+            assert_eq!(expected, &output, "escaping differs for {key}");
+
+            let deserialized: Value = from_str(&output).expect("Failed to round-trip");
+            // Deserialization lowercases keys.
+            assert_eq!(
+                deserialized.get(&key.to_lowercase()).map(|s| s.as_str()),
+                Some(value),
+                "round-trip value mismatch for {key}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

The serializer wraps string values in `"..."` without escaping their contents. Any value containing an internal `"`, `\`, `$`, or newline produces malformed dotenv output that misparses on read-back.

### Reproducer

```rust
let env = Value::from_iter([("JSON", r#"{"bar":"baz"}"#)]);
let s = to_string(&env).unwrap();
// current output:  JSON="{"bar":"baz"}"    <- broken, not round-trippable
// expected output: JSON="{\"bar\":\"baz\"}"
```

This surfaced as a bug in a downstream project ([secretspec#74](https://github.com/cachix/secretspec/issues/74)), where JSON-valued secrets written to `.env` files got corrupted.

## Fix

Escape `\`, `"`, `$`, and `\n` when emitting string values, matching the grammar that `dotenvy`'s weak-quote (double-quote) parser accepts.

## Test plan

- [x] Added `serialize_escapes_special_chars` covering JSON values, backslashes, dollar signs, and newlines — asserts both exact serialized form and round-trip via `from_str`.
- [x] All existing tests still pass (23 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)