### PR TITLE
[WIP] refactor: Use writer without allocating entire output

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     UnsupportedTupleStruct,
     #[error("Unsupported structure in sequence")]
     UnsupportedStructureInSeq,
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
 }
 
 impl ser::Error for Error {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -16,46 +16,57 @@ cfg_if::cfg_if! {
 }
 
 /// A serializer to transform Rust data into environment variables.
-pub struct Serializer {
-    output: String,
+pub struct Serializer<W> {
+    writer: W,
     base_prefix: Option<String>,
     prefix: Vec<String>,
     key: bool,
-    sequence: bool,
+    sequence: SeqState,
     pending_key: bool,
+    first: bool,
 }
 
-impl Serializer {
-    fn new<T: AsRef<str>>(prefix: Option<T>) -> Self {
+enum SeqState {
+    NotSeq,
+    First,
+    Rest,
+}
+
+impl<W: std::io::Write> Serializer<W> {
+    fn new<T: AsRef<str>>(prefix: Option<T>, writer: W) -> Self {
         Self {
-            output: String::new(),
+            writer: writer,
             base_prefix: prefix
                 .map(|s| s.as_ref().to_uppercase())
                 .filter(|s| !s.is_empty()),
             prefix: Vec::new(),
             key: false,
-            sequence: false,
+            sequence: SeqState::NotSeq,
             pending_key: false,
+            first: true,
         }
     }
 
-    pub(crate) fn strip_line_breaks(&mut self) {
-        while self.output.ends_with('\n') {
-            self.output.pop();
-        }
+    pub fn into_inner(self) -> W {
+        self.writer
     }
 
-    fn write_pending_key(&mut self) {
+    fn write_pending_key(&mut self) -> Result<()> {
         if self.pending_key {
             let key = match &self.base_prefix {
                 Some(s) => format!("{}{}", s, self.prefix.join("_")),
                 None => self.prefix.join("_"),
             };
-
-            self.output += &key;
-            self.output += "=";
+            if self.first {
+                self.first = false
+            } else {
+                self.writer.write_all(b"\n")?;
+            }
+            self.writer.write_all(&key.as_bytes())?;
+            self.writer.write_all(b"=")?;
             self.pending_key = false;
-        }
+        };
+        Ok(())
     }
 }
 
@@ -82,10 +93,12 @@ pub fn to_string_inner<T>(prefix: Option<&str>, v: &T) -> Result<String>
 where
     T: serde::ser::Serialize,
 {
-    let mut serializer = Serializer::new(prefix);
+    let vec = Vec::with_capacity(128);
+    let mut serializer = Serializer::new(prefix, vec);
     v.serialize(&mut serializer)?;
-
-    Ok(serializer.output)
+    let out = serializer.into_inner();
+    // Safe because we do not emit invalid UTF-8.
+    Ok(unsafe { String::from_utf8_unchecked(out) })
 }
 
 /// Serialize data to a writer that implements `std::io::Write`.
@@ -112,14 +125,13 @@ where
     to_writer_inner(None, writer, v)
 }
 
-pub(crate) fn to_writer_inner<W, T>(prefix: Option<&str>, mut writer: W, v: &T) -> Result<()>
+pub(crate) fn to_writer_inner<W, T>(prefix: Option<&str>, writer: W, v: &T) -> Result<()>
 where
     W: std::io::Write,
     T: serde::ser::Serialize,
 {
-    writer
-        .write_all(to_string_inner(prefix, v)?.as_bytes())
-        .map_err(Error::new)
+    let mut serializer = Serializer::new(prefix, writer);
+    v.serialize(&mut serializer)
 }
 
 /// Serialize data into an environment variable file.
@@ -152,7 +164,10 @@ where
     to_writer_inner(prefix, file, v)
 }
 
-impl serde::ser::Serializer for &mut Serializer {
+impl<W> serde::ser::Serializer for &mut Serializer<W>
+where
+    W: std::io::Write,
+{
     type Ok = ();
     type Error = Error;
 
@@ -166,8 +181,8 @@ impl serde::ser::Serializer for &mut Serializer {
 
     fn serialize_bool(self, v: bool) -> Result<()> {
         debug!("serialize bool: {}", v);
-        self.write_pending_key();
-        self.output += if v { "true" } else { "false" };
+        self.write_pending_key()?;
+        self.writer.write_all(if v { b"true" } else { b"false" })?;
         Ok(())
     }
 
@@ -188,8 +203,8 @@ impl serde::ser::Serializer for &mut Serializer {
 
     fn serialize_i64(self, v: i64) -> Result<()> {
         debug!("serialize i64: {}", v);
-        self.write_pending_key();
-        self.output += &v.to_string();
+        self.write_pending_key()?;
+        self.writer.write_all(&v.to_string().as_bytes())?;
         Ok(())
     }
 
@@ -210,8 +225,8 @@ impl serde::ser::Serializer for &mut Serializer {
 
     fn serialize_u64(self, v: u64) -> Result<()> {
         debug!("serialize u64: {}", v);
-        self.write_pending_key();
-        self.output += &v.to_string();
+        self.write_pending_key()?;
+        self.writer.write_all(&v.to_string().as_bytes())?;
         Ok(())
     }
 
@@ -222,8 +237,8 @@ impl serde::ser::Serializer for &mut Serializer {
 
     fn serialize_f64(self, v: f64) -> Result<()> {
         debug!("serialize f64: {}", v);
-        self.write_pending_key();
-        self.output += &v.to_string();
+        self.write_pending_key()?;
+        self.writer.write_all(v.to_string().as_bytes())?;
         Ok(())
     }
 
@@ -246,22 +261,22 @@ impl serde::ser::Serializer for &mut Serializer {
             }
             self.prefix.push(upper);
         } else if !v.is_empty() {
-            self.write_pending_key();
-            self.output += "\"";
-
+            self.write_pending_key()?;
+            self.writer.write_all(b"\"")?;
+            let mut b = [0; 4];
             for char in v.chars() {
                 match char {
                     '\n' => {
-                        self.output.push_str("\\n");
+                        self.writer.write_all(b"\\n")?;
                         continue;
                     }
-                    '\\' | '"' | '$' => self.output.push('\\'),
+                    '\\' | '"' | '$' => self.writer.write_all(&[b'\\'])?,
                     _ => (),
                 }
-                self.output.push(char);
+                
+                self.writer.write_all(char.encode_utf8(&mut b).as_bytes())?;
             }
-
-            self.output += "\"";
+            self.writer.write_all(b"\"")?;
         }
         Ok(())
     }
@@ -286,7 +301,7 @@ impl serde::ser::Serializer for &mut Serializer {
 
     fn serialize_unit(self) -> Result<()> {
         debug!("serialize unit");
-        self.write_pending_key();
+        self.write_pending_key()?;
         Ok(())
     }
 
@@ -324,25 +339,24 @@ impl serde::ser::Serializer for &mut Serializer {
         T: ?Sized + serde::ser::Serialize,
     {
         debug!("serialize newtype struct variant: {}", variant);
-        if self.sequence {
+        let SeqState::NotSeq = self.sequence else {
             return value.serialize(&mut *self);
-        }
+        };
 
         self.key = true;
         variant.serialize(&mut *self)?;
         self.key = false;
-        self.output += "=";
+        self.writer.write_all(b"=")?;
         value.serialize(&mut *self)?;
-        self.output += "\n";
         Ok(())
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
         debug!("serialize sequence");
-        if self.sequence {
+        let SeqState::NotSeq = self.sequence else {
             return Err(Error::UnsupportedStructureInSeq);
-        }
-        self.sequence = true;
+        };
+        self.sequence = SeqState::First;
         Ok(self)
     }
 
@@ -373,9 +387,9 @@ impl serde::ser::Serializer for &mut Serializer {
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
         debug!("serialize map");
-        if self.sequence {
+        let SeqState::NotSeq = self.sequence else {
             return Err(Error::UnsupportedStructureInSeq);
-        }
+        };
         Ok(self)
     }
 
@@ -396,7 +410,10 @@ impl serde::ser::Serializer for &mut Serializer {
     }
 }
 
-impl serde::ser::SerializeSeq for &mut Serializer {
+impl<W> serde::ser::SerializeSeq for &mut Serializer<W>
+where
+    W: std::io::Write,
+{
     type Ok = ();
     type Error = Error;
 
@@ -405,21 +422,28 @@ impl serde::ser::SerializeSeq for &mut Serializer {
         T: ?Sized + serde::ser::Serialize,
     {
         debug!("serializing sequence element");
+        match self.sequence {
+            SeqState::First => self.sequence = SeqState::Rest,
+            SeqState::Rest => {
+                self.writer.write_all(b",")?;
+            }
+            SeqState::NotSeq => unreachable!(),
+        }
         let r = value.serialize(&mut **self);
-        self.output += ",";
         r
     }
 
     fn end(self) -> Result<()> {
         debug!("ended serializing sequence element");
-        self.output.pop();
-        self.sequence = false;
-        self.strip_line_breaks();
+        self.sequence = SeqState::NotSeq;
         Ok(())
     }
 }
 
-impl serde::ser::SerializeTuple for &mut Serializer {
+impl<W> serde::ser::SerializeTuple for &mut Serializer<W>
+where
+    W: std::io::Write,
+{
     type Ok = ();
     type Error = Error;
 
@@ -428,21 +452,29 @@ impl serde::ser::SerializeTuple for &mut Serializer {
         T: ?Sized + serde::ser::Serialize,
     {
         debug!("serialize tuple element");
+        match self.sequence {
+            SeqState::First => self.sequence = SeqState::Rest,
+            SeqState::Rest => {
+                self.writer.write_all(b",")?;
+            }
+            SeqState::NotSeq => unreachable!(),
+        }
+
         let r = value.serialize(&mut **self);
-        self.output += ",";
         r
     }
 
     fn end(self) -> Result<()> {
         debug!("ended serializing tuple element");
-        self.output.pop();
-        self.sequence = false;
-        self.strip_line_breaks();
+        self.sequence = SeqState::NotSeq;
         Ok(())
     }
 }
 
-impl serde::ser::SerializeTupleStruct for &mut Serializer {
+impl<W> serde::ser::SerializeTupleStruct for &mut Serializer<W>
+where
+    W: std::io::Write,
+{
     type Ok = ();
     type Error = Error;
 
@@ -451,20 +483,29 @@ impl serde::ser::SerializeTupleStruct for &mut Serializer {
         T: ?Sized + serde::ser::Serialize,
     {
         debug!("serialize tuple struct field");
+        match self.sequence {
+            SeqState::First => self.sequence = SeqState::Rest,
+            SeqState::Rest => {
+                self.writer.write_all(b",")?;
+            }
+            SeqState::NotSeq => unreachable!(),
+        }
+
         let r = value.serialize(&mut **self);
-        self.output += ",";
         r
     }
 
     fn end(self) -> Result<()> {
         debug!("ended serializing tuple struct field");
-        self.output.pop();
-        self.sequence = false;
+        self.sequence = SeqState::NotSeq;
         Ok(())
     }
 }
 
-impl serde::ser::SerializeTupleVariant for &mut Serializer {
+impl<W> serde::ser::SerializeTupleVariant for &mut Serializer<W>
+where
+    W: std::io::Write,
+{
     type Ok = ();
     type Error = Error;
 
@@ -473,20 +514,28 @@ impl serde::ser::SerializeTupleVariant for &mut Serializer {
         T: ?Sized + serde::ser::Serialize,
     {
         debug!("serialize tuple variant field");
+        match self.sequence {
+            SeqState::First => self.sequence = SeqState::Rest,
+            SeqState::Rest => {
+                self.writer.write_all(b",")?;
+            }
+            SeqState::NotSeq => unreachable!(),
+        }
         let r = value.serialize(&mut **self);
-        self.output += ",";
         r
     }
 
     fn end(self) -> Result<()> {
         debug!("ended serializing tuple variant field");
-        self.output.pop();
-        self.sequence = false;
+        self.sequence = SeqState::NotSeq;
         Ok(())
     }
 }
 
-impl serde::ser::SerializeMap for &mut Serializer {
+impl<W> serde::ser::SerializeMap for &mut Serializer<W>
+where
+    W: std::io::Write,
+{
     type Ok = ();
     type Error = Error;
 
@@ -508,12 +557,14 @@ impl serde::ser::SerializeMap for &mut Serializer {
 
     fn end(self) -> Result<()> {
         debug!("ended serializing map");
-        self.strip_line_breaks();
         Ok(())
     }
 }
 
-impl serde::ser::SerializeStruct for &mut Serializer {
+impl<W> serde::ser::SerializeStruct for &mut Serializer<W>
+where
+    W: std::io::Write,
+{
     type Ok = ();
     type Error = Error;
 
@@ -528,12 +579,14 @@ impl serde::ser::SerializeStruct for &mut Serializer {
 
     fn end(self) -> Result<()> {
         debug!("ended serializing struct field");
-        self.strip_line_breaks();
         Ok(())
     }
 }
 
-impl serde::ser::SerializeStructVariant for &mut Serializer {
+impl<W> serde::ser::SerializeStructVariant for &mut Serializer<W>
+where
+    W: std::io::Write,
+{
     type Ok = ();
     type Error = Error;
 
@@ -548,27 +601,30 @@ impl serde::ser::SerializeStructVariant for &mut Serializer {
 
     fn end(self) -> Result<()> {
         debug!("ended serializing struct variant");
-        self.strip_line_breaks();
         Ok(())
     }
 }
 
-fn serialize_field<T>(ser: &'_ mut Serializer, key: &'static str, value: &T) -> Result<()>
+fn serialize_field<T, W: std::io::Write>(
+    ser: &'_ mut Serializer<W>,
+    key: &'static str,
+    value: &T,
+) -> Result<()>
 where
     T: ?Sized + serde::ser::Serialize,
 {
     serialize_map_struct_key(ser, key)?;
-    serialize_map_struct_value::<T>(ser, value)?;
+    serialize_map_struct_value::<T, W>(ser, value)?;
     Ok(())
 }
 
-fn serialize_map_struct_key<T>(ser: &'_ mut Serializer, key: &T) -> Result<()>
+fn serialize_map_struct_key<T, W: std::io::Write>(ser: &'_ mut Serializer<W>, key: &T) -> Result<()>
 where
     T: ?Sized + serde::ser::Serialize,
 {
-    if ser.sequence {
+    let SeqState::NotSeq = ser.sequence else {
         return Err(Error::UnsupportedStructureInSeq);
-    }
+    };
 
     ser.key = true;
     key.serialize(&mut *ser)?;
@@ -577,16 +633,19 @@ where
     Ok(())
 }
 
-fn serialize_map_struct_value<T>(ser: &'_ mut Serializer, value: &T) -> Result<()>
+fn serialize_map_struct_value<T, W: std::io::Write>(
+    ser: &'_ mut Serializer<W>,
+    value: &T,
+) -> Result<()>
 where
     T: ?Sized + serde::ser::Serialize,
 {
-    if ser.sequence {
+    let SeqState::NotSeq = ser.sequence else {
         return Err(Error::UnsupportedStructureInSeq);
-    }
+    };
 
     value.serialize(&mut *ser)?;
-    ser.output += "\n";
+    // ser.writer += "\n";
 
     ser.prefix.pop();
     ser.pending_key = false;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -604,7 +604,7 @@ where
     }
 }
 
-fn serialize_field<T, W: std::io::Write>(
+fn serialize_field<W: std::io::Write, T>(
     ser: &'_ mut Serializer<W>,
     key: &'static str,
     value: &T,
@@ -613,11 +613,11 @@ where
     T: ?Sized + serde::ser::Serialize,
 {
     serialize_map_struct_key(ser, key)?;
-    serialize_map_struct_value::<T, W>(ser, value)?;
+    serialize_map_struct_value::<W, T>(ser, value)?;
     Ok(())
 }
 
-fn serialize_map_struct_key<T, W: std::io::Write>(ser: &'_ mut Serializer<W>, key: &T) -> Result<()>
+fn serialize_map_struct_key<W: std::io::Write, T>(ser: &'_ mut Serializer<W>, key: &T) -> Result<()>
 where
     T: ?Sized + serde::ser::Serialize,
 {
@@ -632,7 +632,7 @@ where
     Ok(())
 }
 
-fn serialize_map_struct_value<T, W: std::io::Write>(
+fn serialize_map_struct_value<W: std::io::Write, T>(
     ser: &'_ mut Serializer<W>,
     value: &T,
 ) -> Result<()>

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -18,7 +18,7 @@ cfg_if::cfg_if! {
 /// A serializer to transform Rust data into environment variables.
 pub struct Serializer {
     output: String,
-    base_prefix: String,
+    base_prefix: Option<String>,
     prefix: Vec<String>,
     key: bool,
     sequence: bool,
@@ -26,10 +26,12 @@ pub struct Serializer {
 }
 
 impl Serializer {
-    fn new(prefix: Option<&str>) -> Self {
+    fn new<T: AsRef<str>>(prefix: Option<T>) -> Self {
         Self {
             output: String::new(),
-            base_prefix: prefix.unwrap_or("").to_uppercase(),
+            base_prefix: prefix
+                .map(|s| s.as_ref().to_uppercase())
+                .filter(|s| !s.is_empty()),
             prefix: Vec::new(),
             key: false,
             sequence: false,
@@ -44,12 +46,10 @@ impl Serializer {
     }
 
     fn build_key(&self) -> String {
-        let base = self.base_prefix.trim_end_matches('_');
-        std::iter::once(base)
-            .filter(|s| !s.is_empty())
-            .chain(self.prefix.iter().map(|s| s.as_str()))
-            .collect::<Vec<_>>()
-            .join("_")
+        match &self.base_prefix {
+            Some(s) => format!("{}{}", s, self.prefix.join("_")),
+            None => self.prefix.join("_"),
+        }
     }
 
     fn write_pending_key(&mut self) {
@@ -556,7 +556,7 @@ impl serde::ser::SerializeStructVariant for &mut Serializer {
     }
 }
 
-fn serialize_field<T>(ser: &'_ mut &'_ mut Serializer, key: &'static str, value: &T) -> Result<()>
+fn serialize_field<T>(ser: &'_ mut Serializer, key: &'static str, value: &T) -> Result<()>
 where
     T: ?Sized + serde::ser::Serialize,
 {
@@ -565,7 +565,7 @@ where
     Ok(())
 }
 
-fn serialize_map_struct_key<T>(ser: &'_ mut &'_ mut Serializer, key: &T) -> Result<()>
+fn serialize_map_struct_key<T>(ser: &'_ mut Serializer, key: &T) -> Result<()>
 where
     T: ?Sized + serde::ser::Serialize,
 {
@@ -574,13 +574,13 @@ where
     }
 
     ser.key = true;
-    key.serialize(&mut **ser)?;
+    key.serialize(&mut *ser)?;
     ser.key = false;
     ser.pending_key = true;
     Ok(())
 }
 
-fn serialize_map_struct_value<T>(ser: &'_ mut &'_ mut Serializer, value: &T) -> Result<()>
+fn serialize_map_struct_value<T>(ser: &'_ mut Serializer, value: &T) -> Result<()>
 where
     T: ?Sized + serde::ser::Serialize,
 {
@@ -588,7 +588,7 @@ where
         return Err(Error::UnsupportedStructureInSeq);
     }
 
-    value.serialize(&mut **ser)?;
+    value.serialize(&mut *ser)?;
     ser.output += "\n";
 
     ser.prefix.pop();

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -576,11 +576,13 @@ where
         return Err(Error::UnsupportedStructureInSeq);
     }
 
+    let saved_prefix = ser.prefix_before.clone();
+
     ser.output += "=";
     value.serialize(&mut **ser)?;
     ser.output += "\n";
 
-    ser.prefix = ser.prefix_before.clone();
+    ser.prefix = saved_prefix;
     Ok(())
 }
 
@@ -633,6 +635,70 @@ mod tests {
 
         //* Then
         assert_eq!("A=1\nB_C=2", output);
+    }
+
+    #[test]
+    fn serialize_to_string_struct_field_after_nested() {
+        #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+        struct Inner {
+            x: u8,
+        }
+
+        #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+        struct Outer {
+            a: u8,
+            inner: Inner,
+            b: u8,
+        }
+
+        let env = Outer {
+            a: 1,
+            inner: Inner { x: 2 },
+            b: 3,
+        };
+
+        let output = to_string(&env).expect("Failed to serialize to string");
+
+        assert_eq!("A=1\nINNER_X=2\nB=3", output);
+    }
+
+    #[test]
+    fn serialize_to_string_deeply_nested_struct() {
+        #[derive(Debug, PartialEq, serde::Serialize)]
+        struct Level2 {
+            z: u8,
+        }
+
+        #[derive(Debug, PartialEq, serde::Serialize)]
+        struct Level1 {
+            y: u8,
+            level2: Level2,
+            y2: u8,
+        }
+
+        #[derive(Debug, PartialEq, serde::Serialize)]
+        struct Root {
+            a: u8,
+            level1: Level1,
+            b: u8,
+        }
+
+        let env = Root {
+            a: 1,
+            level1: Level1 {
+                y: 2,
+                level2: Level2 { z: 3 },
+                y2: 4,
+            },
+            b: 5,
+        };
+
+        let output = to_string(&env).expect("Failed to serialize to string");
+
+        assert_eq!(
+            "A=1\nLEVEL1_Y=2\nLEVEL1_LEVEL2_Z=3\nLEVEL1_Y2=4\nB=5",
+            output
+        );
     }
 
     #[test]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -93,12 +93,11 @@ pub fn to_string_inner<T>(prefix: Option<&str>, v: &T) -> Result<String>
 where
     T: serde::ser::Serialize,
 {
-    let vec = Vec::with_capacity(128);
-    let mut serializer = Serializer::new(prefix, vec);
+    let mut vec = Vec::with_capacity(128);
+    let mut serializer = Serializer::new(prefix, &mut vec);
     v.serialize(&mut serializer)?;
-    let out = serializer.into_inner();
     // Safe because we do not emit invalid UTF-8.
-    Ok(unsafe { String::from_utf8_unchecked(out) })
+    Ok(unsafe { String::from_utf8_unchecked(vec) })
 }
 
 /// Serialize data to a writer that implements `std::io::Write`.

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -21,7 +21,7 @@ pub struct Serializer<W> {
     base_prefix: Option<String>,
     prefix: Vec<String>,
     key: bool,
-    sequence: SeqState,
+    seq_state: SeqState,
     pending_key: bool,
     first: bool,
 }
@@ -41,7 +41,7 @@ impl<W: std::io::Write> Serializer<W> {
                 .filter(|s| !s.is_empty()),
             prefix: Vec::new(),
             key: false,
-            sequence: SeqState::NotSeq,
+            seq_state: SeqState::NotSeq,
             pending_key: false,
             first: true,
         }
@@ -338,7 +338,7 @@ where
         T: ?Sized + serde::ser::Serialize,
     {
         debug!("serialize newtype struct variant: {}", variant);
-        let SeqState::NotSeq = self.sequence else {
+        let SeqState::NotSeq = self.seq_state else {
             return value.serialize(&mut *self);
         };
 
@@ -352,10 +352,10 @@ where
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
         debug!("serialize sequence");
-        let SeqState::NotSeq = self.sequence else {
+        let SeqState::NotSeq = self.seq_state else {
             return Err(Error::UnsupportedStructureInSeq);
         };
-        self.sequence = SeqState::First;
+        self.seq_state = SeqState::First;
         Ok(self)
     }
 
@@ -386,7 +386,7 @@ where
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
         debug!("serialize map");
-        let SeqState::NotSeq = self.sequence else {
+        let SeqState::NotSeq = self.seq_state else {
             return Err(Error::UnsupportedStructureInSeq);
         };
         Ok(self)
@@ -421,8 +421,8 @@ where
         T: ?Sized + serde::ser::Serialize,
     {
         debug!("serializing sequence element");
-        match self.sequence {
-            SeqState::First => self.sequence = SeqState::Rest,
+        match self.seq_state {
+            SeqState::First => self.seq_state = SeqState::Rest,
             SeqState::Rest => {
                 self.writer.write_all(b",")?;
             }
@@ -434,7 +434,7 @@ where
 
     fn end(self) -> Result<()> {
         debug!("ended serializing sequence element");
-        self.sequence = SeqState::NotSeq;
+        self.seq_state = SeqState::NotSeq;
         Ok(())
     }
 }
@@ -451,8 +451,8 @@ where
         T: ?Sized + serde::ser::Serialize,
     {
         debug!("serialize tuple element");
-        match self.sequence {
-            SeqState::First => self.sequence = SeqState::Rest,
+        match self.seq_state {
+            SeqState::First => self.seq_state = SeqState::Rest,
             SeqState::Rest => {
                 self.writer.write_all(b",")?;
             }
@@ -465,7 +465,7 @@ where
 
     fn end(self) -> Result<()> {
         debug!("ended serializing tuple element");
-        self.sequence = SeqState::NotSeq;
+        self.seq_state = SeqState::NotSeq;
         Ok(())
     }
 }
@@ -482,8 +482,8 @@ where
         T: ?Sized + serde::ser::Serialize,
     {
         debug!("serialize tuple struct field");
-        match self.sequence {
-            SeqState::First => self.sequence = SeqState::Rest,
+        match self.seq_state {
+            SeqState::First => self.seq_state = SeqState::Rest,
             SeqState::Rest => {
                 self.writer.write_all(b",")?;
             }
@@ -496,7 +496,7 @@ where
 
     fn end(self) -> Result<()> {
         debug!("ended serializing tuple struct field");
-        self.sequence = SeqState::NotSeq;
+        self.seq_state = SeqState::NotSeq;
         Ok(())
     }
 }
@@ -513,8 +513,8 @@ where
         T: ?Sized + serde::ser::Serialize,
     {
         debug!("serialize tuple variant field");
-        match self.sequence {
-            SeqState::First => self.sequence = SeqState::Rest,
+        match self.seq_state {
+            SeqState::First => self.seq_state = SeqState::Rest,
             SeqState::Rest => {
                 self.writer.write_all(b",")?;
             }
@@ -526,7 +526,7 @@ where
 
     fn end(self) -> Result<()> {
         debug!("ended serializing tuple variant field");
-        self.sequence = SeqState::NotSeq;
+        self.seq_state = SeqState::NotSeq;
         Ok(())
     }
 }
@@ -621,7 +621,7 @@ fn serialize_map_struct_key<T, W: std::io::Write>(ser: &'_ mut Serializer<W>, ke
 where
     T: ?Sized + serde::ser::Serialize,
 {
-    let SeqState::NotSeq = ser.sequence else {
+    let SeqState::NotSeq = ser.seq_state else {
         return Err(Error::UnsupportedStructureInSeq);
     };
 
@@ -639,7 +639,7 @@ fn serialize_map_struct_value<T, W: std::io::Write>(
 where
     T: ?Sized + serde::ser::Serialize,
 {
-    let SeqState::NotSeq = ser.sequence else {
+    let SeqState::NotSeq = ser.seq_state else {
         return Err(Error::UnsupportedStructureInSeq);
     };
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -62,7 +62,7 @@ impl<W: std::io::Write> Serializer<W> {
             } else {
                 self.writer.write_all(b"\n")?;
             }
-            self.writer.write_all(&key.as_bytes())?;
+            self.writer.write_all(key.as_bytes())?;
             self.writer.write_all(b"=")?;
             self.pending_key = false;
         };
@@ -203,7 +203,7 @@ where
     fn serialize_i64(self, v: i64) -> Result<()> {
         debug!("serialize i64: {}", v);
         self.write_pending_key()?;
-        self.writer.write_all(&v.to_string().as_bytes())?;
+        self.writer.write_all(v.to_string().as_bytes())?;
         Ok(())
     }
 
@@ -225,7 +225,7 @@ where
     fn serialize_u64(self, v: u64) -> Result<()> {
         debug!("serialize u64: {}", v);
         self.write_pending_key()?;
-        self.writer.write_all(&v.to_string().as_bytes())?;
+        self.writer.write_all(v.to_string().as_bytes())?;
         Ok(())
     }
 
@@ -269,10 +269,10 @@ where
                         self.writer.write_all(b"\\n")?;
                         continue;
                     }
-                    '\\' | '"' | '$' => self.writer.write_all(&[b'\\'])?,
+                    '\\' | '"' | '$' => self.writer.write_all(b"\\")?,
                     _ => (),
                 }
-                
+
                 self.writer.write_all(char.encode_utf8(&mut b).as_bytes())?;
             }
             self.writer.write_all(b"\"")?;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -45,16 +45,13 @@ impl Serializer {
         }
     }
 
-    fn build_key(&self) -> String {
-        match &self.base_prefix {
-            Some(s) => format!("{}{}", s, self.prefix.join("_")),
-            None => self.prefix.join("_"),
-        }
-    }
-
     fn write_pending_key(&mut self) {
         if self.pending_key {
-            let key = self.build_key();
+            let key = match &self.base_prefix {
+                Some(s) => format!("{}{}", s, self.prefix.join("_")),
+                None => self.prefix.join("_"),
+            };
+
             self.output += &key;
             self.output += "=";
             self.pending_key = false;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -19,10 +19,10 @@ cfg_if::cfg_if! {
 pub struct Serializer {
     output: String,
     base_prefix: String,
-    prefix: String,
+    prefix: Vec<String>,
     key: bool,
     sequence: bool,
-    prefix_before: String,
+    pending_key: bool,
 }
 
 impl Serializer {
@@ -30,16 +30,36 @@ impl Serializer {
         Self {
             output: String::new(),
             base_prefix: prefix.unwrap_or("").to_uppercase(),
-            prefix: "".into(),
+            prefix: Vec::new(),
             key: false,
             sequence: false,
-            prefix_before: "".into(),
+            pending_key: false,
         }
     }
 
     pub(crate) fn strip_line_breaks(&mut self) {
         while self.output.ends_with('\n') {
-            self.output = self.output[..self.output.len() - 1].into();
+            self.output.pop();
+        }
+    }
+
+    fn build_key(&self) -> String {
+        let mut key = self.base_prefix.clone();
+        for part in &self.prefix {
+            if !key.is_empty() && !key.ends_with('_') {
+                key.push('_');
+            }
+            key.push_str(part);
+        }
+        key
+    }
+
+    fn write_pending_key(&mut self) {
+        if self.pending_key {
+            let key = self.build_key();
+            self.output += &key;
+            self.output += "=";
+            self.pending_key = false;
         }
     }
 }
@@ -151,6 +171,7 @@ impl serde::ser::Serializer for &mut Serializer {
 
     fn serialize_bool(self, v: bool) -> Result<()> {
         debug!("serialize bool: {}", v);
+        self.write_pending_key();
         self.output += if v { "true" } else { "false" };
         Ok(())
     }
@@ -172,6 +193,7 @@ impl serde::ser::Serializer for &mut Serializer {
 
     fn serialize_i64(self, v: i64) -> Result<()> {
         debug!("serialize i64: {}", v);
+        self.write_pending_key();
         self.output += &v.to_string();
         Ok(())
     }
@@ -193,6 +215,7 @@ impl serde::ser::Serializer for &mut Serializer {
 
     fn serialize_u64(self, v: u64) -> Result<()> {
         debug!("serialize u64: {}", v);
+        self.write_pending_key();
         self.output += &v.to_string();
         Ok(())
     }
@@ -204,6 +227,7 @@ impl serde::ser::Serializer for &mut Serializer {
 
     fn serialize_f64(self, v: f64) -> Result<()> {
         debug!("serialize f64: {}", v);
+        self.write_pending_key();
         self.output += &v.to_string();
         Ok(())
     }
@@ -217,22 +241,17 @@ impl serde::ser::Serializer for &mut Serializer {
         debug!("serialize &str: {}", v);
 
         if self.key {
-            let mut key = self.base_prefix.clone();
-            if !self.prefix.is_empty() {
-                self.prefix.push('_');
-            }
-            self.prefix += &v.to_uppercase();
-            key += &self.prefix;
-            if key.find(' ').is_some()
-                || key.find('#').is_some()
-                || key.find('\"').is_some()
-                || key.find('\'').is_some()
+            let upper = v.to_uppercase();
+            if upper.contains(' ')
+                || upper.contains('#')
+                || upper.contains('\"')
+                || upper.contains('\'')
             {
                 return Err(Error::Syntax);
             }
-
-            self.output += &key;
+            self.prefix.push(upper);
         } else if !v.is_empty() {
+            self.write_pending_key();
             self.output += "\"";
 
             for char in v.chars() {
@@ -272,6 +291,7 @@ impl serde::ser::Serializer for &mut Serializer {
 
     fn serialize_unit(self) -> Result<()> {
         debug!("serialize unit");
+        self.write_pending_key();
         Ok(())
     }
 
@@ -555,16 +575,10 @@ where
         return Err(Error::UnsupportedStructureInSeq);
     }
 
-    ser.prefix_before = ser.prefix.clone();
-
-    let prefix = format!("{}{}", ser.prefix, '=');
-    if ser.output.ends_with(&prefix) {
-        ser.output = ser.output[..ser.output.len() - prefix.len()].into();
-    }
-
     ser.key = true;
     key.serialize(&mut **ser)?;
     ser.key = false;
+    ser.pending_key = true;
     Ok(())
 }
 
@@ -576,13 +590,11 @@ where
         return Err(Error::UnsupportedStructureInSeq);
     }
 
-    let saved_prefix = ser.prefix_before.clone();
-
-    ser.output += "=";
     value.serialize(&mut **ser)?;
     ser.output += "\n";
 
-    ser.prefix = saved_prefix;
+    ser.prefix.pop();
+    ser.pending_key = false;
     Ok(())
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -44,14 +44,12 @@ impl Serializer {
     }
 
     fn build_key(&self) -> String {
-        let mut key = self.base_prefix.clone();
-        for part in &self.prefix {
-            if !key.is_empty() && !key.ends_with('_') {
-                key.push('_');
-            }
-            key.push_str(part);
-        }
-        key
+        let base = self.base_prefix.trim_end_matches('_');
+        std::iter::once(base)
+            .filter(|s| !s.is_empty())
+            .chain(self.prefix.iter().map(|s| s.as_str()))
+            .collect::<Vec<_>>()
+            .join("_")
     }
 
     fn write_pending_key(&mut self) {


### PR DESCRIPTION
This builds on top of my other PR (#7). When debugging the issue in that PR I noticed that the current implementation would allocate the entire output as a string even when using the `to_writer` function. This PR tries to avoid this.

Having never implemented something like this before I took a lot of inspiration from the `serde_json` crate. The goal is to eventually be able to use the serializer by itself for instance using [`serde_transcode`](https://serde.rs/transcode.html).

I understand that env-files are rarely very large so serializing to memory before outputting is usually not an issue.

There are still some things missing like doc strings and a public `Serializer::new` function, so I'm marking this PR as a draft. I didn't want to sink more time into this before getting feedback.